### PR TITLE
Updates about BitcoinCash

### DIFF
--- a/bitcoinetl/enumeration/chain.py
+++ b/bitcoinetl/enumeration/chain.py
@@ -6,8 +6,7 @@ class Chain:
     DASH = 'dash'
     ZCASH = 'zcash'
     MONACOIN = 'monacoin'
-    BITCOIN_GOLD = 'bitcoin_gold'
 
-    ALL = [BITCOIN, BITCOIN_CASH, DOGECOIN, LITECOIN, DASH, ZCASH, MONACOIN, BITCOIN_GOLD]
+    ALL = [BITCOIN, BITCOIN_CASH, DOGECOIN, LITECOIN, DASH, ZCASH, MONACOIN]
     # Old API doesn't support verbosity for getblock which doesn't allow querying all transactions in a block in 1 go.
-    HAVE_OLD_API = [BITCOIN_CASH, DOGECOIN, DASH, MONACOIN]
+    HAVE_OLD_API = [DOGECOIN, DASH, MONACOIN]

--- a/bitcoinetl/enumeration/chain.py
+++ b/bitcoinetl/enumeration/chain.py
@@ -6,7 +6,8 @@ class Chain:
     DASH = 'dash'
     ZCASH = 'zcash'
     MONACOIN = 'monacoin'
+    BITCOIN_GOLD = 'bitcoin_gold'
 
-    ALL = [BITCOIN, BITCOIN_CASH, DOGECOIN, LITECOIN, DASH, ZCASH, MONACOIN]
+    ALL = [BITCOIN, BITCOIN_CASH, DOGECOIN, LITECOIN, DASH, ZCASH, MONACOIN, BITCOIN_GOLD]
     # Old API doesn't support verbosity for getblock which doesn't allow querying all transactions in a block in 1 go.
     HAVE_OLD_API = [BITCOIN_CASH, DOGECOIN, DASH, MONACOIN]

--- a/bitcoinetl/service/genesis_transactions.py
+++ b/bitcoinetl/service/genesis_transactions.py
@@ -50,7 +50,7 @@ GENESIS_TRANSACTIONS = {
                     "reqSigs": 1,
                     "type": "pubkey",
                     "addresses": [
-                        "1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa"
+                        "bitcoincash:qp3wjpa3tjlj042z2wv7hahsldgwhwy0rq9sywjpyy"
                     ]
                 }
             }


### PR DESCRIPTION
1. The format of address in genesis transaction for BitcoinCash has been legacy style like "1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa", but should be CashAddr style like "bitcoincash:qp3wjpa3tjlj042z2wv7hahsldgwhwy0rq9sywjpyy" to be aligned with other BitcoinCash transactions.
https://cashaddr.bitcoincash.org

2. BitcoinCash node software has supported "getblock with verbosity = 2" option since v0.18.8.
https://github.com/Bitcoin-ABC/bitcoin-abc/releases/tag/v0.18.8
To gain ETL performance, "bitcoin_cash" should be removed from "HAVE_OLD_API" list in chain.py.
