### PR TITLE
Handle bitcoin core 220 rpc output change

### DIFF
--- a/bitcoinetl/mappers/transaction_output_mapper.py
+++ b/bitcoinetl/mappers/transaction_output_mapper.py
@@ -46,7 +46,11 @@ class BtcTransactionOutputMapper(object):
             output.script_hex = script_pub_key.get('hex')
             output.required_signatures = script_pub_key.get('reqSigs')
             output.type = script_pub_key.get('type')
-            output.addresses = script_pub_key.get('addresses')
+            #output.addresses = script_pub_key.get('addresses')
+            if script_pub_key.get('address') is None: 
+              output.addresses = []
+            else:
+              output.addresses = [script_pub_key.get('address')]
 
         return output
 

--- a/bitcoinetl/service/btc_service.py
+++ b/bitcoinetl/service/btc_service.py
@@ -156,7 +156,9 @@ class BtcService(object):
     def _add_non_standard_addresses(self, transaction):
         for output in transaction.outputs:
             if output.addresses is None or len(output.addresses) == 0:
-                output.type = 'nonstandard'
+                #output.type = 'nonstandard'
+                if output.type != 'multisig':
+                    output.type = 'nonstandard'
                 output.addresses = [script_hex_to_non_standard_address(output.script_hex)]
 
     def _add_shielded_inputs_and_outputs(self, transaction):


### PR DESCRIPTION
it works for bitcoin core 22.0. It does not support backward compatibility for bitcoin core prior to core 22.0. 
We can either use bitcoin version to support backward compatibility.