### PR TITLE
Update python-dateutil

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ setup(
     python_requires='>=3.5.0,<4',
     install_requires=[
         'requests~=2.20',
-        'python-dateutil~=2.7',
+        'python-dateutil>=2.7.0',
         'click~=7.0'
     ],
     extras_require={


### PR DESCRIPTION
Hi @medvedev1088 !
We are using ethereumetl and bitcoinetl toghether in one application. 

ethereumetl depends on python-dateutil>=2.8.0 

bitcoinetl depends on python-dateutil==2.7.0 

We have conflicts. Is it possible to bump python-dateutil to >= 2.7.0